### PR TITLE
update create_database.sql, fix issues with procedure and db use

### DIFF
--- a/installation/create_database.sql
+++ b/installation/create_database.sql
@@ -8,6 +8,8 @@ CREATE SCHEMA IF NOT EXISTS `phparcade`
   DEFAULT CHARACTER SET utf8
   DEFAULT COLLATE utf8_general_ci;
 
+USE `phparcade`;
+
 --
 -- Table structure for table `ads`
 --
@@ -1001,8 +1003,8 @@ DELIMITER ;
 DROP PROCEDURE IF EXISTS `sp_Members_GeneratePassword`;
 DELIMITER ;;
 CREATE DEFINER=`phparcade`@`localhost` PROCEDURE `sp_Members_GeneratePassword`(
-  IN hashedpw VARCHAR(255),
-  IN m_username VARCHAR(16))
+  IN m_username VARCHAR(16),
+  IN hashedpw VARCHAR(255))
   BEGIN
     UPDATE `members`
     SET `password` = hashedpw
@@ -1230,5 +1232,3 @@ CREATE DEFINER=`phparcade`@`localhost` PROCEDURE `sp_Sessions_GetSessionbyUserid
     WHERE `userid` = s_userid;
   END ;;
 DELIMITER ;
-
-USE `phparcade`;


### PR DESCRIPTION
Moved the 'Use phparcade' from the bottom of the file to the top of the file (MySQL/Maria couldn't load the script without knowing which DB to use), fixed a procedure statement (the code was sending two arguments in a certain order, the procedure expected them in the opposite order). This would fix issue #16. This is my first pull request, so it's relatively minor edits - just wanted to practice using a GitHub workflow. Thanks!