### PR TITLE
Fix critical and logic bugs in Games and Users

### DIFF
--- a/includes/classes/Games.php
+++ b/includes/classes/Games.php
@@ -338,7 +338,7 @@ class Games
                 break;
             default:
                 $stmt =
-                    mySQL::getConnection()->prepare('CALL sp_Games_GetGames_ActivebyCategory(:releasedate, :category');
+                    mySQL::getConnection()->prepare('CALL sp_Games_GetGames_ActivebyCategory(:releasedate, :category);');
                 $stmt->bindParam(':category', $category);
                 $stmt->bindParam(':releasedate', $time);
                 break;
@@ -358,11 +358,10 @@ class Games
                 $stmt->bindParam(':release_date', $time);
                 $stmt->bindParam(':limitstart', $limitstart);
                 $stmt->bindParam(':limitend', $limitend);
-	            $stmt->execute();
-	            return $stmt->fetchAll();
-                break;
+                $stmt->execute();
+                return $stmt->fetchAll();
             default:
-                echo "ALL?";
+                return [];
         }
     }
     public static function getGamesHomePage()
@@ -435,7 +434,7 @@ class Games
     }
     public static function updateGame($id)
     {
-	$_POST['active'] = property_exists('active', $_POST['active']) ? 'No' : 'Yes';
+        $_POST['active'] = isset($_POST['active']) ? 'No' : 'Yes';
 	$stmt = mySQL::getConnection()->prepare('CALL sp_Games_UpdateGame(:gamename, :gamenameid, :gamedesc, :gamecat, :gamekeywords, :gameflags, :gameinstructions, :gamecustomcode, :gamewidth, :gameheight, :gameactive, :gamerelease, :gameid);');
         $stmt->bindParam(':gamename', $_POST['name']);
         $stmt->bindParam(':gamenameid', $_POST['nameid']);

--- a/includes/classes/Users.php
+++ b/includes/classes/Users.php
@@ -129,7 +129,7 @@ class Users
     public static function UpdateProfile()
     {
         /* Sanitization */
-        $birth_date = '' ? '1970-01-01' : filter_var(strtotime($_POST['birth_date']), FILTER_SANITIZE_NUMBER_INT);
+        $birth_date = $_POST['birth_date'] === '' ? '1970-01-01' : filter_var(strtotime($_POST['birth_date']), FILTER_SANITIZE_NUMBER_INT);
         $email = filter_var($_POST['email'], FILTER_SANITIZE_EMAIL);
         $facebook = filter_var($_POST['facebook_id'], FILTER_SANITIZE_STRING);
         $github = filter_var($_POST['github_id'], FILTER_SANITIZE_STRING);
@@ -148,10 +148,10 @@ class Users
             $stmt->execute();
         } catch (PDOException $e) {
             $params[2] = 'wompwomp';
-            if (!filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
-                Core::showSuccess(gettext('emailvalid'));
-            } else {
+            if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
                 Core::showError(gettext('emailinvalid'));
+            } else {
+                Core::showSuccess(gettext('emailvalid'));
             }
             Core::showError($e->getMessage());
         }


### PR DESCRIPTION
## Summary

- **Games::getGamesCount** – missing closing `)` and `;` in stored procedure call string caused SQL syntax errors
- **Games::getGamesbyReleaseDate_DESC** – removed `echo "ALL?"` debug output and unreachable `break`; default case now returns `[]` instead of `null`
- **Games::updateGame** – `property_exists('active', $_POST['active'])` had arguments reversed, forcing `active` to always `'Yes'`; replaced with `isset($_POST['active'])`
- **Users::UpdateProfile** – `'' ?` ternary condition was always falsy so the `1970-01-01` birth date default never triggered; fixed to `$_POST['birth_date'] === ''`
- **Users::UpdateProfile** – `!filter_var($email, FILTER_VALIDATE_EMAIL) === false` double-negative inverted the email validation result; fixed to straightforward `=== false` check

## Test plan

- [ ] Verify category page game counts display correctly
- [ ] Verify RSS feed returns games (calls `getGamesbyReleaseDate_DESC`)
- [ ] Edit a game in admin and confirm active/inactive toggles correctly
- [ ] Update a user profile with a blank birth date and confirm it saves as `1970-01-01`
- [ ] Update a user profile with an invalid email and confirm the error message shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)